### PR TITLE
fix char replacement in `secret_key` for mac

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -57,7 +57,8 @@ aws_strategy() {
       echo "Fetching secret from AWS secrets manager"
       ssh_key="$(aws secretsmanager get-secret-value --secret-id "${secret_key}" --region "${region}" | jq -r '.SecretString' | base64 --decode)"
 
-      ssh_key_file="${SECRETS_DIR}"/"${secret_key//\//\-}" # replace "/" in secret_key with "-"
+      clean_secret_key=$(echo "$secret_key" | sed 's#/#-#g') # replace "/" in secret_key with "-"
+      ssh_key_file="${SECRETS_DIR}"/"${clean_secret_key}"
       touch "${ssh_key_file}"
       chmod 0600 "${ssh_key_file}"
       echo "$ssh_key" >> "${ssh_key_file}"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -57,6 +57,7 @@ aws_strategy() {
       echo "Fetching secret from AWS secrets manager"
       ssh_key="$(aws secretsmanager get-secret-value --secret-id "${secret_key}" --region "${region}" | jq -r '.SecretString' | base64 --decode)"
 
+      # shellcheck disable=SC2001
       clean_secret_key=$(echo "$secret_key" | sed 's#/#-#g') # replace "/" in secret_key with "-"
       ssh_key_file="${SECRETS_DIR}"/"${clean_secret_key}"
       touch "${ssh_key_file}"


### PR DESCRIPTION
Previously we were replacing `/` in `secret_key` with `-` using shell parameter expansion([ref](https://stackoverflow.com/a/13210909)) 
https://github.com/hasura/smooth-secrets-buildkite-plugin/blob/c2c32b2fc9787798ee24781a2308c8ba481e18a6/hooks/pre-checkout#L60
But we found during a release that the behaviour in mac is different than expected. 

In this PR I have used sed instead of bash magic to achieve the desired result. **This however is also still untested for mac.**

https://github.com/hasura/graphql-engine-mono/issues/3582

Edit: tested on mac and it works as expected