### PR TITLE
avoid stop the world sudo command in cleanup phase

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -7,11 +7,11 @@ echo "Killing ssh-agent with PID ${SSH_AGENT_PID}"
 eval "$(ssh-agent -k)"
 
 echo "Removing secrets directory: ${SECRETS_DIR}"
-# rm -rf "${SECRETS_DIR}" || {
-#   echo "Tried running: rm -rf ${SECRETS_DIR}"
-#   echo "But it failed leaving the following files as residue"
-#   ls -la "${SECRETS_DIR}"
-# }
+rm -rf "${SECRETS_DIR}" || {
+  echo "Tried running: rm -rf ${SECRETS_DIR}"
+  echo "But it failed leaving the following files as residue"
+  ls -la "${SECRETS_DIR}"
+}
 
 if [ -d "${SECRETS_DIR}" ]; then
   echo "Attempting to remove with sudo"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -5,6 +5,25 @@ set -eo pipefail
 echo "--- :lock: Cleaning up secrets"
 echo "Killing ssh-agent with PID ${SSH_AGENT_PID}"
 eval "$(ssh-agent -k)"
+
 echo "Removing secrets directory: ${SECRETS_DIR}"
-sudo rm -rf "${SECRETS_DIR}"
-echo "Secrets directory removed."
+rm -rf "${SECRETS_DIR}" || {
+  echo "Tried running: rm -rf ${SECRETS_DIR}"
+  echo "But it failed leaving the following files as residue"
+  ls -la "${SECRETS_DIR}"
+}
+
+if [ -d "${SECRETS_DIR}" ]; then
+  echo "Attempting to remove with sudo"
+  sudo -n rm -rf "${SECRETS_DIR}" || {
+    echo "Tried running: sudo -n rm -rf ${SECRETS_DIR}"
+    echo "But it failed leaving the following files as residue"
+    ls -la "${SECRETS_DIR}"
+  }
+fi
+
+if [ ! -d "${SECRETS_DIR}" ]; then
+  echo "Secrets directory removed."
+else
+  echo "Failure in cleaning up the secrets directory"
+fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -7,11 +7,11 @@ echo "Killing ssh-agent with PID ${SSH_AGENT_PID}"
 eval "$(ssh-agent -k)"
 
 echo "Removing secrets directory: ${SECRETS_DIR}"
-rm -rf "${SECRETS_DIR}" || {
-  echo "Tried running: rm -rf ${SECRETS_DIR}"
-  echo "But it failed leaving the following files as residue"
-  ls -la "${SECRETS_DIR}"
-}
+# rm -rf "${SECRETS_DIR}" || {
+#   echo "Tried running: rm -rf ${SECRETS_DIR}"
+#   echo "But it failed leaving the following files as residue"
+#   ls -la "${SECRETS_DIR}"
+# }
 
 if [ -d "${SECRETS_DIR}" ]; then
   echo "Attempting to remove with sudo"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -25,5 +25,5 @@ fi
 if [ ! -d "${SECRETS_DIR}" ]; then
   echo "Secrets directory removed."
 else
-  echo "Failure in cleaning up the secrets directory"
+  echo "Failure in cleaning up the secrets directory."
 fi


### PR DESCRIPTION
There are cases where the build gets stuck forever waiting for password while trying to do sudo rm -rf in the clean up section

![image](https://github.com/hasura/smooth-checkout-buildkite-plugin/assets/4211715/7dc9dc01-930a-44e3-a635-a076e649d5ee)

This PR tries to avoid such cases.

Equivalent of https://github.com/hasura/smooth-checkout-buildkite-plugin/pull/47